### PR TITLE
rpc client process, private wallet breakage

### DIFF
--- a/src/blocks/change_block.rs
+++ b/src/blocks/change_block.rs
@@ -1,19 +1,11 @@
 use crate::blocks::BlockHash;
 use crate::{Public, Signature, Work};
-use clap::Clap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChangeBlock {
-    #[clap(short, long)]
     previous: BlockHash,
-
-    #[clap(short, long)]
     representative: Public,
-
-    #[clap(short, long)]
     pub work: Option<Work>,
-
-    #[clap(short = 'g', long)]
     pub signature: Option<Signature>,
 }

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -19,18 +19,20 @@ use crate::{Private, Public, Rai, Signature, Work};
 use anyhow::{anyhow, Context};
 pub use block_hash::BlockHash;
 pub use change_block::ChangeBlock;
-use clap::Clap;
 use core::convert::TryFrom;
 pub use open_block::OpenBlock;
 pub use receive_block::ReceiveBlock;
 pub use send_block::SendBlock;
 use serde;
 use serde::{Deserialize, Serialize};
+pub(crate) use state_block::deserialize_to_unsure_link;
 pub use state_block::{Link, StateBlock, Subtype};
+use strum_macros::EnumString;
 use tracing::trace;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum BlockType {
     Invalid,
     NotABlock,
@@ -74,7 +76,7 @@ impl TryFrom<u8> for BlockType {
 }
 
 /// For "holding" deserialized blocks that we can't convert to `Block` yet.
-#[derive(Debug, Clone, Serialize, Deserialize, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BlockHolder {
     Send(SendBlock),

--- a/src/blocks/open_block.rs
+++ b/src/blocks/open_block.rs
@@ -1,27 +1,19 @@
 use crate::blocks::BlockHash;
 use crate::keys::public::{from_address, to_address};
 use crate::{Public, Signature, Work};
-use clap::Clap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OpenBlock {
-    /// BlockHash of the Open block sending the funds to this account.
-    #[clap(short, long)]
     pub source: BlockHash,
 
     #[serde(serialize_with = "to_address", deserialize_with = "from_address")]
-    #[clap(short, long)]
     pub representative: Public,
 
     #[serde(serialize_with = "to_address", deserialize_with = "from_address")]
-    #[clap(short, long)]
     pub account: Public,
 
-    #[clap(short, long)]
     pub work: Option<Work>,
-
-    #[clap(short = 'g', long)]
     pub signature: Option<Signature>,
 }
 

--- a/src/blocks/receive_block.rs
+++ b/src/blocks/receive_block.rs
@@ -1,19 +1,11 @@
 use crate::blocks::BlockHash;
 use crate::{Public, Signature, Work};
-use clap::Clap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReceiveBlock {
-    #[clap(short, long)]
     previous: BlockHash,
-
-    #[clap(short, long)]
     source: Public,
-
-    #[clap(short, long)]
     pub work: Option<Work>,
-
-    #[clap(short = 'g', long)]
     pub signature: Option<Signature>,
 }

--- a/src/blocks/send_block.rs
+++ b/src/blocks/send_block.rs
@@ -9,31 +9,24 @@ use crate::bytes::Bytes;
 use crate::keys::public::{from_address, to_address};
 use crate::units::rai::{deserialize_from_hex, serialize_to_hex};
 use crate::{Public, Rai, Signature, Work};
-use clap::Clap;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SendBlock {
     /// The hash of the previous block in this account.
-    #[clap(short, long)]
     pub previous: BlockHash,
 
     #[serde(serialize_with = "to_address", deserialize_with = "from_address")]
-    #[clap(short, long)]
     pub destination: Public,
 
     #[serde(
         serialize_with = "serialize_to_hex",
         deserialize_with = "deserialize_from_hex"
     )]
-    #[clap(short, long)]
     pub balance: Rai,
 
-    #[clap(short, long)]
     pub work: Option<Work>,
-
-    #[clap(short = 'g', long)]
     pub signature: Option<Signature>,
 }
 

--- a/src/blocks/state_block.rs
+++ b/src/blocks/state_block.rs
@@ -10,7 +10,6 @@ use crate::encoding::deserialize_from_str;
 use crate::keys::public::{from_address, to_address};
 use crate::Result;
 use crate::{expect_len, to_hex, Error, Public, Rai, Signature, Work};
-use clap::Clap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fmt::Debug;
@@ -29,6 +28,7 @@ where
 
 /// Not used within StateBlock yet.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, EnumString)]
+#[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Subtype {
     Send,
@@ -38,30 +38,23 @@ pub enum Subtype {
     Epoch,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StateBlock {
     #[serde(serialize_with = "to_address", deserialize_with = "from_address")]
-    #[clap(short, long)]
     pub account: Public,
 
-    #[clap(short, long)]
     pub previous: BlockHash,
 
     #[serde(serialize_with = "to_address", deserialize_with = "from_address")]
-    #[clap(short, long)]
     pub representative: Public,
 
-    #[clap(short, long)]
     pub balance: Rai,
 
     #[serde(deserialize_with = "deserialize_to_unsure_link")]
-    #[clap(short, long)]
     pub link: Link,
 
-    #[clap(short, long)]
     pub work: Option<Work>,
 
-    #[clap(short = 'g', long)]
     pub signature: Option<Signature>,
 }
 

--- a/src/rpc/calls/block_create.rs
+++ b/src/rpc/calls/block_create.rs
@@ -1,4 +1,4 @@
-use crate::blocks::{BlockHash, Link, StateBlock};
+use crate::blocks::{BlockHash, BlockType, Link, StateBlock};
 use crate::rpc::client::{RPCClient, RPCRequest};
 use crate::rpc::AlwaysTrue;
 use crate::wallet::WalletId;
@@ -13,33 +13,44 @@ pub struct BlockCreateRequest {
     #[clap(skip)]
     json_block: AlwaysTrue,
 
+    /// Specify the block type. It currently only makes sense to use `state` for new blocks.
+    #[clap(short = 't', long, default_value = "state")]
+    #[serde(rename = "type")]
+    block_type: BlockType,
+
     /// Final balance for account after block creation.
     #[clap(short, long)]
     pub balance: Rai,
 
     /// The wallet ID that the account the block is being created for is in.
     #[clap(short = 'i', long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub wallet: Option<WalletId>,
 
     /// The account the block is being created for.
     #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<Address>,
 
     /// Instead of using "wallet" & "account" parameters, you can directly pass in a private key.
     #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<Private>,
 
     /// The block hash of the source of funds for this receive block
     #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<Private>,
 
     /// The account that the sent funds should be accessible to.
     #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub destination: Option<Private>,
 
     /// Instead of using "source" & "destination" parameters, you can directly pass "link".
     /// Source block hash to receive or destination public key to send.
     #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub link: Option<Link>,
 
     /// The account that block account will use as its representative.
@@ -47,16 +58,22 @@ pub struct BlockCreateRequest {
     pub representative: Address,
 
     /// The block hash of the previous block on this account's block chain.
-    /// Leave blank for the first block in the account.
-    #[clap(short, long)]
+    /// Do not specify if it's for the first block in the account.
+    #[clap(
+        short,
+        long,
+        default_value = "0000000000000000000000000000000000000000000000000000000000000000"
+    )]
     pub previous: BlockHash,
 
     /// Specify own work.
     #[clap(short, long, group = "work_or_difficulty")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub work: Option<Work>,
 
     /// Uses difficulty value to generate work. Only used if optional work is not given.
     #[clap(short = 'f', long, group = "work_or_difficulty")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub difficulty: Option<Difficulty>,
 }
 
@@ -74,9 +91,15 @@ impl RPCRequest for &BlockCreateRequest {
 }
 
 impl BlockCreateRequest {
-    pub fn new(balance: Rai, representative: Address, previous: BlockHash) -> Self {
+    pub fn new(
+        block_type: BlockType,
+        balance: Rai,
+        representative: Address,
+        previous: BlockHash,
+    ) -> Self {
         Self {
             json_block: Default::default(),
+            block_type,
             balance,
             wallet: None,
             account: None,

--- a/src/rpc/calls/process.rs
+++ b/src/rpc/calls/process.rs
@@ -1,10 +1,42 @@
-use crate::blocks::{StateBlock, Subtype};
+use crate::blocks::{deserialize_to_unsure_link, BlockType};
+use crate::blocks::{BlockHash, Link, Subtype};
 use crate::rpc::client::{RPCClient, RPCRequest};
 use crate::rpc::AlwaysTrue;
-use crate::Result;
+use crate::{Address, Rai, Result, Signature, Work};
 use async_trait::async_trait;
 use clap::Clap;
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+pub struct StateBlockRequest {
+    #[clap(short = 't', long, default_value = "state")]
+    #[serde(rename = "type")]
+    pub block_type: BlockType,
+
+    #[clap(short, long)]
+    pub account: Address,
+
+    #[clap(short, long)]
+    pub previous: BlockHash,
+
+    #[clap(short, long)]
+    pub representative: Address,
+
+    #[clap(short, long)]
+    pub balance: Rai,
+
+    #[serde(deserialize_with = "deserialize_to_unsure_link")]
+    #[clap(short, long)]
+    pub link: Link,
+
+    #[clap(short, long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work: Option<Work>,
+
+    #[clap(short = 'g', long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Signature>,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clap)]
 pub struct ProcessRequest {
@@ -15,7 +47,7 @@ pub struct ProcessRequest {
     pub subtype: Subtype,
 
     #[clap(flatten)]
-    pub block: StateBlock,
+    pub block: StateBlockRequest,
 }
 
 #[async_trait]


### PR DESCRIPTION
* RPC call process seems to work now (at least once!)
* Private keys now serialize to hex string instead of Vec<u8>
* Removed clap from block code