### PR TITLE
Hex struct macro

### DIFF
--- a/src/blocks/block_hash.rs
+++ b/src/blocks/block_hash.rs
@@ -1,5 +1,5 @@
 use crate::encoding::{deserialize_from_str, hex_formatter};
-use crate::{expect_len, to_hex};
+use crate::{expect_len, hexify, to_hex};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::str::FromStr;
@@ -7,73 +7,18 @@ use std::str::FromStr;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct BlockHash([u8; BlockHash::LEN]);
 
+hexify!(BlockHash, "block hash");
+
 impl BlockHash {
     pub const LEN: usize = 32;
 
     pub fn zero() -> Self {
         Self([0u8; BlockHash::LEN])
     }
-
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl FromStr for BlockHash {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        BlockHash::try_from(hex::decode(s.as_bytes())?.as_slice())
-    }
-}
-
-impl TryFrom<&[u8]> for BlockHash {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        expect_len(value.len(), Self::LEN, "Block hash")?;
-
-        let mut bh = BlockHash([0u8; Self::LEN]);
-        bh.0.copy_from_slice(&value);
-        Ok(bh)
-    }
 }
 
 impl std::fmt::Display for BlockHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:X}", &self)
-    }
-}
-
-impl std::fmt::Debug for BlockHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BlockHash(")?;
-        hex_formatter(f, &self.0)?;
-        write!(f, ")")?;
-        Ok(())
-    }
-}
-
-impl std::fmt::UpperHex for BlockHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        hex_formatter(f, &self.0.as_ref())
-    }
-}
-
-impl Serialize for BlockHash {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(to_hex(&self.0).as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for BlockHash {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize_from_str(deserializer)
     }
 }

--- a/src/blocks/block_hash.rs
+++ b/src/blocks/block_hash.rs
@@ -1,6 +1,4 @@
-use crate::encoding::{deserialize_from_str, hex_formatter};
-use crate::{expect_len, hexify, to_hex};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use crate::hexify;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
@@ -14,11 +12,5 @@ impl BlockHash {
 
     pub fn zero() -> Self {
         Self([0u8; BlockHash::LEN])
-    }
-}
-
-impl std::fmt::Display for BlockHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", &self)
     }
 }

--- a/src/blocks/block_hash.rs
+++ b/src/blocks/block_hash.rs
@@ -1,6 +1,4 @@
 use crate::hexify;
-use std::convert::TryFrom;
-use std::str::FromStr;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct BlockHash([u8; BlockHash::LEN]);

--- a/src/blocks/change_block.rs
+++ b/src/blocks/change_block.rs
@@ -3,7 +3,7 @@ use crate::{Public, Signature, Work};
 use clap::Clap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Clap)]
+#[derive(Debug, Clone, PartialEq, Eq, Clap)]
 pub struct ChangeBlock {
     #[clap(short, long)]
     previous: BlockHash,

--- a/src/blocks/change_block.rs
+++ b/src/blocks/change_block.rs
@@ -2,7 +2,7 @@ use crate::blocks::BlockHash;
 use crate::{Public, Signature, Work};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChangeBlock {
     previous: BlockHash,
     representative: Public,

--- a/src/blocks/state_block.rs
+++ b/src/blocks/state_block.rs
@@ -6,11 +6,9 @@ use crate::node::Wire;
 
 use crate::blocks::{BlockHash, BlockType};
 use crate::bytes::Bytes;
-use crate::encoding::deserialize_from_str;
 use crate::keys::public::{from_address, to_address};
-use crate::Result;
-use crate::{expect_len, to_hex, Error, Public, Rai, Signature, Work};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use crate::{expect_len, hexify, Error, Public, Rai, Result, Signature, Work};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -165,61 +163,13 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct UnsureLink([u8; Link::LEN]);
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct UnsureLink([u8; Self::LEN]);
+
+hexify!(UnsureLink, "link");
 
 impl UnsureLink {
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl TryFrom<&[u8]> for UnsureLink {
-    type Error = Error;
-
-    fn try_from(value: &[u8]) -> Result<Self> {
-        expect_len(value.len(), Link::LEN, "UnsureLink")?;
-
-        let mut v = UnsureLink([0u8; Link::LEN]);
-        v.0.copy_from_slice(&value);
-        Ok(v)
-    }
-}
-
-impl Serialize for UnsureLink {
-    fn serialize<S>(
-        &self,
-        serializer: S,
-    ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(to_hex(&self.0).as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for UnsureLink {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize_from_str(deserializer)
-    }
-}
-
-impl FromStr for UnsureLink {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        UnsureLink::try_from(
-            hex::decode(s.as_bytes())
-                .map_err(|source| Error::FromHexError {
-                    msg: "UnsureLink".to_string(),
-                    source,
-                })?
-                .as_slice(),
-        )
-    }
+    pub(crate) const LEN: usize = Link::LEN;
 }
 
 /// Used in state block as a reference to either the previous block or a destination address.

--- a/src/cli/wallet.rs
+++ b/src/cli/wallet.rs
@@ -24,17 +24,17 @@ impl WalletOpts {
                             o.phrase_opts.language.language.to_owned(),
                         )
                         .await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
                 CreateType::Seed(o) => {
                     let (manager, wallet_id) = WalletOpts::create(&o.opts).await?;
                     manager.add_random_seed(wallet_id.to_owned()).await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
                 CreateType::Private(o) => {
                     let (manager, wallet_id) = WalletOpts::create(&o.opts).await?;
                     manager.add_random_private(wallet_id.to_owned()).await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
             },
             Command::Import(o) => match &o.create_type {
@@ -46,19 +46,19 @@ impl WalletOpts {
                     )?;
                     let wallet = Wallet::Phrase(phrase);
                     manager.add(wallet_id.to_owned(), wallet).await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
                 ImportType::Seed(o) => {
                     let (manager, wallet_id) = WalletOpts::create(&o.opts).await?;
                     let wallet = Wallet::Seed(o.seed.to_owned().resolve()?);
                     manager.add(wallet_id.to_owned(), wallet).await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
                 ImportType::Private(o) => {
                     let (manager, wallet_id) = WalletOpts::create(&o.opts).await?;
                     let wallet = Wallet::Private(o.private.to_owned().resolve()?);
                     manager.add(wallet_id.to_owned(), wallet).await?;
-                    println!("{:?}", wallet_id);
+                    println!("{}", wallet_id);
                 }
             },
             Command::Delete(o) => {
@@ -86,7 +86,7 @@ impl WalletOpts {
                 if o.armor {
                     println!("{}", Armor::new(string, wallet.address(o.address)?, signed));
                 } else {
-                    println!("{:X}", signed);
+                    println!("{}", signed);
                 }
             }
         };

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -194,7 +194,7 @@ macro_rules! hexify {
             fn serialize<S>(
                 &self,
                 serializer: S,
-            ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+            ) -> ::std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
             where
                 S: serde::Serializer,
             {
@@ -205,7 +205,7 @@ macro_rules! hexify {
         impl<'de> serde::Deserialize<'de> for $struct {
             fn deserialize<D>(
                 deserializer: D,
-            ) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
+            ) -> ::std::result::Result<Self, <D as serde::Deserializer<'de>>::Error>
             where
                 D: serde::Deserializer<'de>,
             {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -116,6 +116,7 @@ pub fn decode_nano_base_32(s: &str) -> Result<BitVec<Msb0, u8>, Error> {
 /// * `TryFrom<&[u8]>` implementation.
 /// * [FromStr] implementation, which parses hex into its type.
 /// * [Debug] implementation, which displays as StructName(H3XSTR1NG), e.g. Work(A1B2C3).
+/// * [Display] implementation, which displays the hex string.
 /// * [UpperHex] and [LowerHex] implementations.
 ///
 /// Display implementation is not implemented for any user customization.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -140,8 +140,8 @@ macro_rules! hexify {
             type Err = crate::Error;
 
             fn from_str(s: &str) -> crate::Result<Self> {
-                expect_len(s.len(), Self::LEN * 2, $description)?;
-                let vec = hex::decode(s.as_bytes()).map_err(|e| Error::FromHexError {
+                crate::expect_len(s.len(), Self::LEN * 2, $description)?;
+                let vec = hex::decode(s.as_bytes()).map_err(|e| crate::Error::FromHexError {
                     msg: String::from($description),
                     source: e,
                 })?;
@@ -151,8 +151,14 @@ macro_rules! hexify {
             }
         }
 
-        impl std::fmt::Debug for $struct {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl ::std::fmt::Display for $struct {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{}", self.as_hex())
+            }
+        }
+
+        impl ::std::fmt::Debug for $struct {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(
                     f,
                     "{}({})",
@@ -171,7 +177,7 @@ macro_rules! hexify {
         }
 
         impl ::std::fmt::UpperHex for $struct {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(f, "{}", self.as_hex())
             }
         }
@@ -201,8 +207,8 @@ macro_rules! hexify {
             where
                 D: serde::Deserializer<'de>,
             {
-                let s: &str = serde::Deserialize::deserialize(deserializer)?;
-                Ok(Self::from_str(s).map_err(serde::de::Error::custom)?)
+                let s: String = serde::Deserialize::deserialize(deserializer)?;
+                Ok(Self::from_str(&s).map_err(serde::de::Error::custom)?)
             }
         }
     };

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -14,9 +14,24 @@ pub fn to_hex(bytes: &[u8]) -> String {
     s
 }
 
+pub fn to_hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        s.push_str(&format!("{:02x}", byte));
+    }
+    s
+}
+
 pub fn hex_formatter(f: &mut std::fmt::Formatter<'_>, bytes: &[u8]) -> std::fmt::Result {
     for byte in bytes {
         write!(f, "{:02X}", byte)?;
+    }
+    Ok(())
+}
+
+pub fn hex_formatter_lower(f: &mut std::fmt::Formatter<'_>, bytes: &[u8]) -> std::fmt::Result {
+    for byte in bytes {
+        write!(f, "{:02x}", byte)?;
     }
     Ok(())
 }
@@ -90,6 +105,107 @@ pub fn decode_nano_base_32(s: &str) -> Result<BitVec<Msb0, u8>, Error> {
     }
 
     Ok(bits)
+}
+
+/// This macro relies on the `struct` to be a newtype containing a slice of `[u8; $struct::LEN]`.
+///
+/// It adds:
+/// * serde implementations to (de)serialize hex strings.
+/// * `pub fn as_bytes(&self) -> &[u8]`
+/// * `pub fn as_hex(&self) -> String`
+/// * `TryFrom<&[u8]>` implementation.
+/// * [FromStr] implementation, which parses hex into its type.
+/// * [Debug] implementation, which displays as StructName(H3XSTR1NG), e.g. Work(A1B2C3).
+/// * [UpperHex] and [LowerHex] implementations.
+///
+/// Display implementation is not implemented for any user customization.
+#[macro_export]
+macro_rules! hexify {
+    ($struct:ident, $description:expr) => {
+        impl $struct {
+            pub fn as_bytes(&self) -> &[u8] {
+                &self.0
+            }
+
+            pub fn as_hex(&self) -> String {
+                crate::encoding::to_hex(&self.0)
+            }
+
+            pub fn as_hex_lower(&self) -> String {
+                crate::encoding::to_hex_lower(&self.0)
+            }
+        }
+
+        impl ::std::str::FromStr for $struct {
+            type Err = crate::Error;
+
+            fn from_str(s: &str) -> crate::Result<Self> {
+                expect_len(s.len(), Self::LEN * 2, $description)?;
+                let vec = hex::decode(s.as_bytes()).map_err(|e| Error::FromHexError {
+                    msg: String::from($description),
+                    source: e,
+                })?;
+                let bytes = vec.as_slice();
+                let x = <[u8; Self::LEN]>::try_from(bytes)?;
+                Ok(Self(x))
+            }
+        }
+
+        impl std::fmt::Debug for $struct {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "{}({})",
+                    stringify!($struct),
+                    crate::encoding::to_hex(self.0.as_ref()),
+                )
+            }
+        }
+
+        impl ::std::convert::TryFrom<&[u8]> for $struct {
+            type Error = crate::Error;
+
+            fn try_from(v: &[u8]) -> crate::Result<Self> {
+                Ok(Self(<[u8; Self::LEN]>::try_from(v)?))
+            }
+        }
+
+        impl ::std::fmt::UpperHex for $struct {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{}", self.as_hex())
+            }
+        }
+
+        impl ::std::fmt::LowerHex for $struct {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{}", self.as_hex_lower())
+            }
+        }
+
+        impl serde::Serialize for $struct {
+            fn serialize<S>(
+                &self,
+                serializer: S,
+            ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(self.as_hex().as_str())
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $struct {
+            fn deserialize<D>(
+                deserializer: D,
+            ) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s: &str = serde::Deserialize::deserialize(deserializer)?;
+                Ok(Self::from_str(s).map_err(serde::de::Error::custom)?)
+            }
+        }
+    };
 }
 
 #[cfg(test)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -140,6 +140,8 @@ macro_rules! hexify {
             type Err = crate::Error;
 
             fn from_str(s: &str) -> crate::Result<Self> {
+                use ::std::convert::TryFrom;
+
                 crate::expect_len(s.len(), Self::LEN * 2, $description)?;
                 let vec = hex::decode(s.as_bytes()).map_err(|e| crate::Error::FromHexError {
                     msg: String::from($description),
@@ -207,6 +209,7 @@ macro_rules! hexify {
             where
                 D: serde::Deserializer<'de>,
             {
+                use ::std::str::FromStr;
                 let s: String = serde::Deserialize::deserialize(deserializer)?;
                 Ok(Self::from_str(&s).map_err(serde::de::Error::custom)?)
             }

--- a/src/keys/private.rs
+++ b/src/keys/private.rs
@@ -1,15 +1,15 @@
-use crate::Error;
-use crate::{expect_len, Address, Public, Signature};
+use crate::{expect_len, hexify, Address, Error, Public, Signature};
 use ed25519_dalek::ed25519::signature::Signature as InternalSignature;
 use ed25519_dalek::ExpandedSecretKey;
 use rand::RngCore;
-use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::str::FromStr;
 
 /// 256 bit private key which can generate a public key.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone)]
 pub struct Private([u8; Private::LEN]);
+
+hexify!(Private, "private key");
 
 impl Private {
     pub(crate) const LEN: usize = 32;
@@ -69,39 +69,9 @@ impl Private {
     }
 }
 
-impl TryFrom<&[u8]> for Private {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        expect_len(bytes.len(), Private::LEN, "Private key")?;
-        let x = <[u8; Self::LEN]>::try_from(bytes)?;
-        Ok(Self(x))
-    }
-}
-
-impl std::fmt::UpperHex for Private {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::encoding::hex_formatter(f, &self.0)
-    }
-}
-
 impl std::fmt::Display for Private {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:X}", &self)
-    }
-}
-
-impl FromStr for Private {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        expect_len(s.len(), Self::LEN * 2, "hex private key")?;
-        let vec = hex::decode(s.as_bytes()).map_err(|e| Error::FromHexError {
-            msg: String::from("Decoding hex public key"),
-            source: e,
-        })?;
-        let bytes = vec.as_slice();
-        Self::try_from(bytes)
     }
 }
 

--- a/src/keys/private.rs
+++ b/src/keys/private.rs
@@ -3,7 +3,6 @@ use ed25519_dalek::ed25519::signature::Signature as InternalSignature;
 use ed25519_dalek::ExpandedSecretKey;
 use rand::RngCore;
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 /// 256 bit private key which can generate a public key.
 #[derive(Clone)]

--- a/src/keys/private.rs
+++ b/src/keys/private.rs
@@ -1,4 +1,4 @@
-use crate::{expect_len, hexify, Address, Error, Public, Signature};
+use crate::{hexify, Address, Error, Public, Signature};
 use ed25519_dalek::ed25519::signature::Signature as InternalSignature;
 use ed25519_dalek::ExpandedSecretKey;
 use rand::RngCore;
@@ -66,16 +66,6 @@ impl Private {
                 source: e,
             })?,
         )
-    }
-
-    pub fn as_hex(&self) -> String {
-        to_hex(self.0.as_ref())
-    }
-}
-
-impl std::fmt::Display for Private {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", &self)
     }
 }
 

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -6,7 +6,7 @@ use crate::node::Header;
 
 use crate::hexify;
 use crate::Error;
-use crate::{encoding, expect_len, Address, Signature};
+use crate::{encoding, Address, Signature};
 use bitvec::prelude::*;
 use ed25519_dalek::Verifier;
 use serde::{Deserialize, Deserializer, Serializer};
@@ -69,12 +69,6 @@ impl Public {
 impl From<ed25519_dalek::PublicKey> for Public {
     fn from(v: ed25519_dalek::PublicKey) -> Self {
         Self(*v.as_bytes())
-    }
-}
-
-impl std::fmt::Display for Public {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", &self)
     }
 }
 

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -10,7 +10,6 @@ use crate::{encoding, Address, Signature};
 use bitvec::prelude::*;
 use ed25519_dalek::Verifier;
 use serde::{Deserialize, Deserializer, Serializer};
-use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::str::FromStr;
 

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -4,12 +4,12 @@ use crate::node::Wire;
 #[cfg(feature = "node")]
 use crate::node::Header;
 
-use crate::encoding::deserialize_from_str;
+use crate::hexify;
 use crate::Error;
-use crate::{encoding, expect_len, to_hex, Address, Signature};
+use crate::{encoding, expect_len, Address, Signature};
 use bitvec::prelude::*;
 use ed25519_dalek::Verifier;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::str::FromStr;
@@ -17,6 +17,8 @@ use std::str::FromStr;
 /// 256 bit public key which can be converted into an [Address](crate::Address) or verify a [Signature](crate::Signature).
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Public([u8; Public::LEN]);
+
+hexify!(Public, "public key");
 
 impl Public {
     pub const LEN: usize = 32;
@@ -29,14 +31,6 @@ impl Public {
                 source: e,
             })?,
         )
-    }
-
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    pub fn as_hex(&self) -> String {
-        to_hex(self.0.as_ref())
     }
 
     pub fn to_address(&self) -> Address {
@@ -72,75 +66,15 @@ impl Public {
     }
 }
 
-impl FromStr for Public {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        expect_len(s.len(), Self::LEN * 2, "hex public key")?;
-        let vec = hex::decode(s.as_bytes()).map_err(|e| Error::FromHexError {
-            msg: String::from("Decoding hex public key"),
-            source: e,
-        })?;
-        let bytes = vec.as_slice();
-
-        let x = <[u8; Self::LEN]>::try_from(bytes)?;
-
-        Ok(Self(x))
-    }
-}
-
-impl std::fmt::Debug for Public {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Public({} {})",
-            to_hex(self.0.as_ref()),
-            self.to_address()
-        )
-    }
-}
-
-impl TryFrom<&[u8]> for Public {
-    type Error = Error;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self(<[u8; Self::LEN]>::try_from(value)?))
-    }
-}
-
 impl From<ed25519_dalek::PublicKey> for Public {
     fn from(v: ed25519_dalek::PublicKey) -> Self {
         Self(*v.as_bytes())
     }
 }
 
-impl std::fmt::UpperHex for Public {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::encoding::hex_formatter(f, &self.0)
-    }
-}
-
 impl std::fmt::Display for Public {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:X}", &self)
-    }
-}
-
-impl Serialize for Public {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(to_hex(&self.0).as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for Public {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize_from_str(deserializer)
     }
 }
 

--- a/src/keys/seed.rs
+++ b/src/keys/seed.rs
@@ -4,7 +4,6 @@ use crate::Private;
 use bytes::{BufMut, BytesMut};
 use rand::RngCore;
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 /// 256 bit seed used to derive multiple addresses.
 ///

--- a/src/keys/seed.rs
+++ b/src/keys/seed.rs
@@ -1,11 +1,9 @@
-use crate::encoding::{blake2b, deserialize_from_string};
-use crate::Error;
-use crate::{expect_len, to_hex, Private};
+use crate::encoding::blake2b;
+use crate::hexify;
+use crate::Private;
 use bytes::{BufMut, BytesMut};
 use rand::RngCore;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
-use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
 /// 256 bit seed used to derive multiple addresses.
@@ -13,6 +11,8 @@ use std::str::FromStr;
 /// See https://docs.nano.org/integration-guides/the-basics/#seed for details.
 #[derive(Clone, PartialEq)]
 pub struct Seed(pub [u8; Seed::LEN]);
+
+hexify!(Seed, "seed");
 
 impl Seed {
     const LEN: usize = 32;
@@ -40,60 +40,5 @@ impl Seed {
 
         // Expect this to work all the time because it's coming from known correct types.
         Private::try_from(result.as_ref()).expect("conversion from seed")
-    }
-}
-
-impl FromStr for Seed {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        expect_len(s.len(), Seed::LEN * 2, "Seed")?;
-        let mut seed = Seed::zero();
-        hex::decode_to_slice(s, &mut seed.0).map_err(|e| Error::FromHexError {
-            msg: String::from("Decoding seed"),
-            source: e,
-        })?;
-        Ok(seed)
-    }
-}
-
-impl TryFrom<&[u8]> for Seed {
-    type Error = Error;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        expect_len(value.len(), Seed::LEN, "Seed")?;
-        let mut seed = Seed::zero();
-        seed.0.copy_from_slice(value);
-        Ok(seed)
-    }
-}
-
-impl std::fmt::Display for Seed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::encoding::hex_formatter(f, &self.0)
-    }
-}
-
-impl Debug for Seed {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        crate::encoding::hex_formatter(f, &self.0)
-    }
-}
-
-impl Serialize for Seed {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(to_hex(&self.0).as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for Seed {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize_from_string(deserializer)
     }
 }

--- a/src/keys/signature.rs
+++ b/src/keys/signature.rs
@@ -1,15 +1,11 @@
-use crate::encoding::{deserialize_from_str, hex_formatter};
-use crate::Error;
-use crate::{expect_len, to_hex};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::convert::TryFrom;
-use std::fmt::{Debug, Display};
-use std::str::FromStr;
+use crate::hexify;
 
 /// A ed25519+blake2 signature that can be generated with [Private](crate::Private) and
 /// checked with [Public](crate::Public).
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Signature([u8; Signature::LEN]);
+
+hexify!(Signature, "signature");
 
 impl Signature {
     pub(crate) const LEN: usize = 64;
@@ -18,68 +14,7 @@ impl Signature {
         Self([0u8; Signature::LEN])
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
     pub(crate) fn internal(&self) -> ed25519_dalek::Signature {
         ed25519_dalek::Signature::new(self.0)
-    }
-}
-
-impl FromStr for Signature {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Signature::try_from(
-            hex::decode(s.as_bytes())
-                .map_err(|e| Error::FromHexError {
-                    msg: String::from("Decoding signature"),
-                    source: e,
-                })?
-                .as_slice(),
-        )
-    }
-}
-
-impl Serialize for Signature {
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(to_hex(&self.0).as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for Signature {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize_from_str(deserializer)
-    }
-}
-
-impl Display for Signature {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        hex_formatter(f, self.0.as_ref())
-    }
-}
-
-impl TryFrom<&[u8]> for Signature {
-    type Error = Error;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        expect_len(value.len(), Self::LEN, "Signature")?;
-
-        let mut s = Signature::zero();
-        s.0.copy_from_slice(value);
-        Ok(s)
-    }
-}
-
-impl std::fmt::UpperHex for Signature {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::encoding::hex_formatter(f, &self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod rpc;
 pub mod units;
 pub mod vanity;
 
+// TODO: Remove to_hex and hex_formatter from root
 pub(crate) use encoding::{hex_formatter, to_hex};
 pub use errors::{Error, Result};
 pub use keys::address::Address;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ pub mod rpc;
 pub mod units;
 pub mod vanity;
 
-// TODO: Remove to_hex and hex_formatter from root
-pub(crate) use encoding::{hex_formatter, to_hex};
+// TODO: Remove to_hex from root
+pub(crate) use encoding::to_hex;
 pub use errors::{Error, Result};
 pub use keys::address::Address;
 pub use keys::phrase;

--- a/src/rpc/calls/process.rs
+++ b/src/rpc/calls/process.rs
@@ -1,4 +1,4 @@
-use crate::blocks::{deserialize_to_unsure_link, BlockType};
+use crate::blocks::{deserialize_to_unsure_link, BlockType, StateBlock};
 use crate::blocks::{BlockHash, Link, Subtype};
 use crate::rpc::client::{RPCClient, RPCRequest};
 use crate::rpc::AlwaysTrue;
@@ -64,12 +64,8 @@ impl RPCRequest for &ProcessRequest {
 }
 
 impl ProcessRequest {
-    pub fn new(subtype: Subtype, block: StateBlock) -> Self {
-        Self {
-            json_block: Default::default(),
-            subtype,
-            block,
-        }
+    pub fn new(_subtype: Subtype, _block: StateBlock) -> Self {
+        todo!()
     }
 }
 

--- a/src/rpc/calls/process.rs
+++ b/src/rpc/calls/process.rs
@@ -32,8 +32,12 @@ impl RPCRequest for &ProcessRequest {
 }
 
 impl ProcessRequest {
-    pub fn new() -> Self {
-        todo!()
+    pub fn new(subtype: Subtype, block: StateBlock) -> Self {
+        Self {
+            json_block: Default::default(),
+            subtype,
+            block,
+        }
     }
 }
 


### PR DESCRIPTION
This macro relies on the `struct` to be a newtype containing a slice of `[u8; $struct::LEN]`.

It adds:
* serde implementations to (de)serialize hex strings.
* `pub fn as_bytes(&self) -> &[u8]`
* `pub fn as_hex(&self) -> String`
* `TryFrom<&[u8]>` implementation.
* `FromStr` implementation, which parses hex into its type.
* `Debug` implementation, which displays as `StructName(H3XSTR1NG)`, e.g. `Work(A1B2C3)`.
* `Display` implementation, which displays the hex string.
* `UpperHex` and `LowerHex` implementations.

Display implementation is not implemented for any user customization.
